### PR TITLE
Uppercase insensivity testing

### DIFF
--- a/tests/test_namecounter.py
+++ b/tests/test_namecounter.py
@@ -40,6 +40,24 @@ class TestNameCounter(unittest.TestCase):
 
         return data
 
+    def dataDifferenCase(self):
+        data = PacketsExample()
+
+        for i in range(5) :
+            data.addPacket({'flags': '8000', 'queries' : [{'qname' : 'www.nic.cl'}]})
+        for i in range(5) :
+            data.addPacket({'flags': '8000', 'queries' : [{'qname' : 'WWW.NIC.CL'}]})
+        data.setExpected('www.nic.cl', 10)
+
+
+        for i in range(5) :
+            data.addPacket({'flags': '8000', 'queries' : [{'qname' : 'WWW:NIC.CL'}]})
+        for i in range(5) :
+            data.addPacket({'flags': '8000', 'queries' : [{'qname' : 'wwww.nic.cl'}]})
+        data.putInformation('criticalQName','www.nic.cl')
+        return data
+
+
     def setUp(self):
         self.reInit()
 
@@ -99,6 +117,17 @@ class TestNameCounter(unittest.TestCase):
         for qname in result.keys():
             self.assertEquals(example.expectedValue(qname) ,result[qname])
 
+    def test_dataDifferentCase(self):
+        self.reInit()
+
+        example = self.dataDifferenCase()
+        for packet in example:
+            self.__p1(packet)
+
+        result = self.__p1.get_data()
+
+        critical = example.getInformation('criticalQName')
+        self.assertEquals(example.expectedValue(critical), result[critical])
 
     def test_reset(self):
         self.reInit()

--- a/tests/test_namecounter.py
+++ b/tests/test_namecounter.py
@@ -40,8 +40,6 @@ class TestNameCounter(unittest.TestCase):
 
         return data
 
-        return data
-
     def setUp(self):
         self.reInit()
 

--- a/tests/test_qwhn.py
+++ b/tests/test_qwhn.py
@@ -62,6 +62,26 @@ class TestQueriesWithUnderscoredName(unittest.TestCase):
         return data
 
 
+    def dataDifferenCase(self):
+        data = PacketsExample()
+        data.putInformation('problematicQName','www.ni_c.cl')
+
+        expectedList = []
+
+        data.addPacket({'dest' : 'encrypted(dnsip1)', 'source' : 'encrypted(ip1)','flags': '0', 'queries' : [{'qname' : 'www.ni_c.cl', 'qtype' : '1'}]})
+        expectedList.append({'server' : 'encrypted(dnsip1)', 'sender' : 'encrypted(ip1)','query': {'qname' : 'www.ni_c.cl', 'qtype' : '1'}})
+
+        data.addPacket({'dest' : 'encrypted(dnsip1)', 'source' : 'encrypted(ip1)','flags': '0', 'queries' : [{'qname' : 'WWW.NI_C.CL', 'qtype' : '1'}]})
+        expectedList.append({'server' : 'encrypted(dnsip1)', 'sender' : 'encrypted(ip1)','query': {'qname' : 'WWW.NI_C.CL', 'qtype' : '1'}})
+
+        data.setExpected('www.ni_c.cl', expectedList)
+
+
+        data.addPacket({'dest' : 'encrypted(dnsip1)', 'source' : 'encrypted(ip1)','flags': '0', 'queries' : [{'qname' : 'wwww.ni_c.cl', 'qtype' : '1'}]})
+        data.addPacket({'dest' : 'encrypted(dnsip1)', 'source' : 'encrypted(ip1)','flags': '0', 'queries' : [{'qname' : 'WWW:NI_C.CL', 'qtype' : '1'}]})
+
+        return data
+
     def dataRepeatError(self):
         data = PacketsExample()
         data.putInformation('problematicQNames', {'www.ni_c.cl', 'www.nic_labs.cl'})
@@ -146,6 +166,19 @@ class TestQueriesWithUnderscoredName(unittest.TestCase):
             self.assertTrue(result.has_key(source))
             self.assertEquals(example.expectedValue(source), result[source])
 
+    def test_dataDifferenCase(self):
+        self.reInit()
+
+        example = self.dataDifferenCase()
+        for packet in example:
+            self.__p1(packet)
+
+        result = self.__p1.get_data()
+        expectedProblematic = example.getInformation('problematicQName')
+
+
+        self.assertTrue(result.has_key(expectedProblematic))
+        self.assertEquals(example.expectedValue(expectedProblematic), result[expectedProblematic])
 
     def test_dataRepeatError(self):
         self.reInit()

--- a/tests/test_topn.py
+++ b/tests/test_topn.py
@@ -39,6 +39,23 @@ class TestTopN(unittest.TestCase):
 
         return data
 
+    def dataDifferentCase(self):
+        queries = {'www.nic.cl' : 5, 'www.niclabs.cl' : 10}
+        data = PacketsExample(queries)
+        data.putInformation('sortedQnames', sorted(queries.items(), key=operator.itemgetter(1), reverse=True)) #Returns a list with the elements of the dict in descending order of its keys
+
+        for i in range(5) :
+            data.addPacket({'flags': '0', 'queries' : [{'qname' : 'www.nic.cl'}]})
+        for i in range(5) :
+            data.addPacket({'flags': '0', 'queries' : [{'qname' : 'WWW.NIC.CL'}]})
+
+        for i in range(5) :
+            data.addPacket({'flags': '0', 'queries' : [{'qname' : 'www.niclabs.cl'}]})
+        for i in range(6) :
+            data.addPacket({'flags': '0', 'queries' : [{'qname' : 'WwWW.NicLaBs.cl'}]})
+
+        return data
+
     def dataEqualRating(self):
         n = 10
         queries = {'www.nic.cl' : n, 'www.niclabs.cl' : n, 'www.uchile.cl' : n, 'www.jerry.cl' : n, 'www.pinky.cl' : n}
@@ -169,6 +186,22 @@ class TestTopN(unittest.TestCase):
             self.assertTrue(result.has_key(qname))
             self.assertEquals(example.expectedValue(qname) ,result[qname])
 
+    def test_dataDifferentCase(self):
+        n = 3
+        self.reInit(n)
+
+        example = self.dataDifferentCase()
+        for packet in example:
+            self.__p1(packet)
+
+        result = self.__p1.get_data()
+
+        self.assertEquals(n, len(result))
+        tops = example.getInformation('sortedQnames')
+        for i in range(n):
+            qname = tops[i][0]
+            self.assertTrue(result.has_key(qname))
+            self.assertEquals(example.expectedValue(qname) ,result[qname])
 
     def test_reset(self):
         n = 3

--- a/tests/test_topnq.py
+++ b/tests/test_topnq.py
@@ -43,6 +43,23 @@ class TestTopNQ(unittest.TestCase):
 
         return data
 
+    def dataDifferentCase(self):
+        queries = {'www.nic.cl' : 5, 'www.niclabs.cl' : 10}
+        data = PacketsExample(queries)
+        data.putInformation('sortedQnames', sorted(queries.items(), key=operator.itemgetter(1), reverse=True)) #Returns a list with the elements of the dict in descending order of its keys
+
+        for i in range(5) :
+            data.addPacket({'flags': '0', 'queries' : [{'qname' : 'www.nic.cl'}]})
+        for i in range(5) :
+            data.addPacket({'flags': '0', 'queries' : [{'qname' : 'WWW.NIC.CL'}]})
+
+        for i in range(5) :
+            data.addPacket({'flags': '0', 'queries' : [{'qname' : 'www.niclabs.cl'}]})
+        for i in range(6) :
+            data.addPacket({'flags': '0', 'queries' : [{'qname' : 'WwWW.NicLaBs.cl'}]})
+
+        return data
+
     def dataJustAnswers(self):
 
         data = PacketsExample()
@@ -183,7 +200,22 @@ class TestTopNQ(unittest.TestCase):
             self.assertTrue(result.has_key(qname))
             self.assertEquals(example.expectedValue(qname) ,result[qname])
 
+    def test_dataDifferentCase(self):
+        n = 3
+        self.reInit(n)
 
+        example = self.dataDifferentCase()
+        for packet in example:
+            self.__p1(packet)
+
+        result = self.__p1.get_data()
+
+        self.assertEquals(n, len(result))
+        tops = example.getInformation('sortedQnames')
+        for i in range(n):
+            qname = tops[i][0]
+            self.assertTrue(result.has_key(qname))
+            self.assertEquals(example.expectedValue(qname) ,result[qname])
 
     def test_dataJustAnswers(self):
         self.reInit()


### PR DESCRIPTION
Analysis of case insensitivity for qnames in PreRs.
Critical PreRs identified :
- NameCounter(counts by qname)
- QueriesWithUnderscoredName(group by qname)
- TopN and TopNQ(same than NameCounter)
--> Added test for these cases