### PR TITLE
Manage parameters of PreR through configuration files

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -44,18 +44,24 @@ class Options:
             PreR = getattr(importlib.import_module(prers_path + "." + module_name), class_name)
             prer_args = dict(config.items(class_name))
 
-            output_method = prer_args['outputmethod']
+            output_method = prer_args.pop('outputmethod')
+
             if output_method == 'stdout':
-                prer = PreR(sys.stdout)
+                f = sys.stdout
             elif output_method == 'file':
-                f = open(prer_args['filename'], 'a')
-                prer = PreR(f)
+                f = open(prer_args.pop('filename'), 'a')
             elif output_method == 'redis':
-                host = prer_args['redishost']
-                channel = prer_args['redischannel']
-                prer = PreR(RedisFile(host, channel))
+                host = prer_args.pop('redishost')
+                channel = prer_args.pop('redischannel')
+                f = RedisFile(host, channel)
             else: # Default Output Method
-                prer = PreR(sys.stdout)
+                f = sys.stdout
+
+            prer = PreR(f, **prer_args)
+            # if not prer_args:
+            #     prer = PreR(f)
+            # else:
+            #     prer = PreR(f, **prer_args)
 
             self.prers.append(prer)
 

--- a/prers/topn.py
+++ b/prers/topn.py
@@ -28,10 +28,10 @@ class TopN(PreR):
     <FILL>
     """
 
-    def __init__(self, f, n=100):
+    def __init__(self, f, **kwargs):
         PreR.__init__(self, f)
         self.names = {}
-        self.n = n
+        self.n = kwargs['n']
 
     def __call__(self, p):
         qname = p.qname

--- a/prers/topnpp.py
+++ b/prers/topnpp.py
@@ -4,9 +4,9 @@ from core import PacketPocket
 
 
 class TopNPP(PreR):
-    def __init__(self, f, k=100):
+    def __init__(self, f, **kwargs):
         PreR.__init__(self, f)
-        self.k = k
+        self.k = kwargs['n']
         self.packetpocket = PacketPocket(self.k)
 
     def __call__(self, p):

--- a/prers/topnq.py
+++ b/prers/topnq.py
@@ -27,10 +27,10 @@ class TopNQ(PreR):
 
     <FILL>
     """
-    def __init__(self, f, n=100):
+    def __init__(self, f, **kwargs):
         PreR.__init__(self, f)
         self.names = {}
-        self.n = n
+        self.n = kwargs['n']
 
     def __call__(self, p):
         qname = p.qname


### PR DESCRIPTION
Make configurable the specific parameters of some PreR through the configuration file. For example, the TopN PreR needs "N", the ranking size.

### Example of the configuration file ###
[TopN]
\# ...
N=100
\# ...
